### PR TITLE
Switch to build.Default.GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ mock_display_test.go
 debug.test
 .vscode
 *.coverprofile
+.idea
+*.iml

--- a/pegomock/main_test.go
+++ b/pegomock/main_test.go
@@ -17,6 +17,7 @@ package main_test
 import (
 	"bytes"
 	"os"
+	"go/build"
 	"path/filepath"
 	"strings"
 
@@ -49,7 +50,7 @@ var _ = Describe("CLI", func() {
 	)
 
 	BeforeEach(func() {
-		packageDir = joinPath(os.Getenv("GOPATH"), "src", "pegomocktest")
+		packageDir = joinPath(build.Default.GOPATH, "src", "pegomocktest")
 		Expect(os.MkdirAll(packageDir, 0755)).To(Succeed())
 		subPackageDir = joinPath(packageDir, "subpackage")
 		Expect(os.MkdirAll(subPackageDir, 0755)).To(Succeed())

--- a/pegomock/util/input.go
+++ b/pegomock/util/input.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +34,7 @@ func SourceArgs(args []string) ([]string, error) {
 		if e != nil {
 			panic(e)
 		}
-		packagePath, err := packagePathFromDirectory(os.Getenv("GOPATH"), workingDir)
+		packagePath, err := packagePathFromDirectory(build.Default.GOPATH, workingDir)
 		if err != nil {
 			return nil, fmt.Errorf("Couldn't determine package path from directory: %v", err)
 		}

--- a/pegomock/watch/watch_test.go
+++ b/pegomock/watch/watch_test.go
@@ -15,6 +15,7 @@
 package watch_test
 
 import (
+	"go/build"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +42,7 @@ var _ = Describe("NewMockFileUpdater", func() {
 	)
 
 	BeforeEach(func() {
-		packageDir = joinPath(os.Getenv("GOPATH"), "src", "pegomocktest")
+		packageDir = joinPath(build.Default.GOPATH, "src", "pegomocktest")
 		Expect(os.MkdirAll(packageDir, 0755)).To(Succeed())
 		subPackageDir = joinPath(packageDir, "subpackage")
 		Expect(os.MkdirAll(subPackageDir, 0755)).To(Succeed())


### PR DESCRIPTION
Latest versions of golang don't require `GOPATH` environment
variable to be set. Safer to rely on this which still checks for the environment variable.