### PR TITLE
Fix invalid chars in matcher file and function names

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -426,7 +426,7 @@ func optionalPackageOf(t model.Type, packageMap map[string]string) string {
 func spaceSeparatedNameFor(t model.Type, packageMap map[string]string) string {
 	switch typedType := t.(type) {
 	case model.PredeclaredType:
-		// replace call non-alphanumeric characters from type string
+		// replace all non-alphanumeric characters from type string
 		rgx := regexp.MustCompile("[^a-zA-Z0-9]+")
 		return rgx.ReplaceAllString(typedType.String(packageMap, ""), "")
 	case *model.NamedType:

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -27,7 +27,6 @@ import (
 	"go/format"
 	"go/token"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -426,9 +425,13 @@ func optionalPackageOf(t model.Type, packageMap map[string]string) string {
 func spaceSeparatedNameFor(t model.Type, packageMap map[string]string) string {
 	switch typedType := t.(type) {
 	case model.PredeclaredType:
-		// replace all non-alphanumeric characters from type string
-		rgx := regexp.MustCompile("[^a-zA-Z0-9]+")
-		return rgx.ReplaceAllString(typedType.String(packageMap, ""), "")
+		tt := typedType.String(packageMap, "")
+		if tt == "interface{}" {
+			// if a predeclared type is interface
+			// return a string type without curly brackets
+			return "interface"
+		}
+		return tt
 	case *model.NamedType:
 		return strings.Replace((typedType.String(packageMap, "")), ".", " ", -1)
 	case *model.PointerType:

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -27,6 +27,7 @@ import (
 	"go/format"
 	"go/token"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -425,7 +426,9 @@ func optionalPackageOf(t model.Type, packageMap map[string]string) string {
 func spaceSeparatedNameFor(t model.Type, packageMap map[string]string) string {
 	switch typedType := t.(type) {
 	case model.PredeclaredType:
-		return typedType.String(packageMap, "")
+		// replace call non-alphanumeric characters from type string
+		rgx := regexp.MustCompile("[^a-zA-Z0-9]+")
+		return rgx.ReplaceAllString(typedType.String(packageMap, ""), "")
 	case *model.NamedType:
 		return strings.Replace((typedType.String(packageMap, "")), ".", " ", -1)
 	case *model.PointerType:

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Mockgen", func() {
 			_, matcherSourceCodes := mockgen.GenerateOutput(ast, "irrelevant", "test_package", "")
 
 			Expect(matcherSourceCodes).To(SatisfyAll(
-				HaveLen(5),
+				HaveLen(6),
 				HaveKeyWithValue("http_request", SatisfyAll(
 					ContainSubstring("http \"net/http\""),
 					ContainSubstring("func AnyHttpRequest() http.Request"),
@@ -34,6 +34,9 @@ var _ = Describe("Mockgen", func() {
 				)),
 				HaveKeyWithValue("io_readcloser", SatisfyAll(
 					ContainSubstring("func AnyIoReadCloser() io.ReadCloser"),
+				)),
+				HaveKeyWithValue("map_of_string_to_interface", SatisfyAll(
+					ContainSubstring("func AnyMapOfStringToInterface() map[string]interface{}"),
 				)),
 			))
 		})

--- a/test_interface/display.go
+++ b/test_interface/display.go
@@ -37,4 +37,5 @@ type Display interface {
 	VariadicParam(v ...string)
 	NormalAndVariadicParam(s string, i int, v ...string)
 	CamelCaseTypeParam(camelCaseParam io.ReadCloser)
+	MapOfStringToInterfaceParam(m map[string]interface{})
 }


### PR DESCRIPTION
Fixes genaration of names for matcher function and files. For instance, when a mock file and matchers are generated for an interface such as: 
```
type Iface interface{
   DoSomeWork(s string, vars map[string]interface{}) error
}
```
Generated matcher file for map of strings to interface will result in name **map_of_string_to_interface{}.go**  with the following content: 

```
package matchers

import (
	"reflect"
	"github.com/petergtz/pegomock"
	

)

func AnyMapOfStringToInterface{}() map[string]interface{} {
	pegomock.RegisterMatcher(pegomock.NewAnyMatcher(reflect.TypeOf((*(map[string]interface{}))(nil)).Elem()))
	var nullValue map[string]interface{}
	return nullValue
}

func EqMapOfStringToInterface{}(value map[string]interface{}) map[string]interface{} {
	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
	var nullValue map[string]interface{}
	return nullValue
} 
```
While a file with the name containing curly brackets is still usable, Go does not allow to have curly brackets in function names, which is currently has to be corrected manually every time the mock and matchers are regenerated.