### PR TITLE
Ability to use a non-existing directory in the path of --output flag 

### DIFF
--- a/pegomock/filehandling/filehandling.go
+++ b/pegomock/filehandling/filehandling.go
@@ -26,6 +26,15 @@ func GenerateMockFileInOutputDir(
 	out io.Writer,
 	useExperimentalModelGen bool,
 	shouldGenerateMatchers bool) {
+
+	// if a file path override is specified
+	// ensure all directories in the path are created
+	if outputFilePathOverride != "" {
+		if err := os.MkdirAll(filepath.Dir(outputFilePathOverride), 0755); err != nil {
+			panic(fmt.Errorf("Failed to make output directory, error: %v", err))
+		}
+	}
+
 	GenerateMockFile(
 		args,
 		OutputFilePath(args, outputDirPath, outputFilePathOverride),

--- a/pegomock/main_test.go
+++ b/pegomock/main_test.go
@@ -16,8 +16,8 @@ package main_test
 
 import (
 	"bytes"
-	"os"
 	"go/build"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,7 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/petergtz/pegomock/pegomock"
+	main "github.com/petergtz/pegomock/pegomock"
 	. "github.com/petergtz/pegomock/pegomock/testutil"
 
 	"testing"
@@ -139,6 +139,16 @@ var _ = Describe("CLI", func() {
 				var buf bytes.Buffer
 				main.Run(cmd("pegomock generate -d mydisplay.go"), &buf, app, done)
 				Expect(buf.String()).To(ContainSubstring("- method Show"))
+			})
+		})
+
+		Context("with args -o where output override is a path with a non-existing directory", func() {
+			It(`creates an output directory before code generation`, func() {
+				var buf bytes.Buffer
+				main.Run(cmd("pegomock generate mydisplay.go -o testoutput/test.go"), &buf, app, done)
+				Expect(joinPath(packageDir, "testoutput/test.go")).To(SatisfyAll(
+					BeAnExistingFile(),
+					BeAFileContainingSubString("package pegomocktest_test")))
 			})
 		})
 


### PR DESCRIPTION
Hi @petergtz, 

The proposed change is to enable creation of non-existing directory structure in the path of --output flag.

When using pegomock with `go generate`  it is sometimes required to create mock files and matchers in a separate directory that might not exist at the time of running the command. 

Thank you for your time.