### PR TITLE
Resolves #98 - Too many open files on Recursive Remove

### DIFF
--- a/pegomock/remove/remove.go
+++ b/pegomock/remove/remove.go
@@ -157,6 +157,12 @@ func isPegomockGenerated(path string, out io.Writer) bool {
 		fmt.Fprintf(out, "Could not open file %v. Error: %v\n", path, e)
 		return false
 	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			fmt.Fprintf(out, "Could not close file %v. Error: %v\n", path, closeErr)
+		}
+	}()
+
 	b := make([]byte, 50)
 	_, e = file.Read(b)
 	if e != nil {


### PR DESCRIPTION
- Doing a recursive remove on a large dir/tree structure causes TooManyOpenFiles error
- Added closing of opened file using defer