### PR TITLE
Fix a bug when multiple interfaces were parsed

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -76,10 +76,11 @@ func (g *generator) generateCode(source string, pkg *model.Package, structName, 
 	g.p(")")
 
 	for _, iface := range pkg.Interfaces {
-		if structName == "" {
-			structName = "Mock" + iface.Name
+		sName := structName
+		if sName == "" {
+			sName = "Mock" + iface.Name
 		}
-		g.generateMockFor(iface, structName, selfPackage)
+		g.generateMockFor(iface, sName, selfPackage)
 	}
 }
 


### PR DESCRIPTION
Fix #103 

The loop was writing to a variable out of the scope and the second time it goes through `if structName == "" {` the condition was never false because the out of scope variable was updated with the first

It resulted in all generated interfaces being named the same (even if the implementation was distinct for each)

