### PR TITLE
Avoid duplicate imports when generating matchers of map types

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -470,7 +470,12 @@ func optionalPackageOf(t model.Type, packageMap map[string]string) string {
 	case *model.ArrayType:
 		return optionalPackageOf(typedType.Type, packageMap)
 	case *model.MapType:
-		return optionalPackageOf(typedType.Key, packageMap) + "\n" + optionalPackageOf(typedType.Value, packageMap)
+		keyPackage := optionalPackageOf(typedType.Key, packageMap)
+		valuePackage := optionalPackageOf(typedType.Value, packageMap)
+		if keyPackage == valuePackage {
+			return keyPackage
+		}
+		return keyPackage + "\n" + valuePackage
 	case *model.ChanType:
 		return optionalPackageOf(typedType.Type, packageMap)
 		// TODO:

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Mockgen", func() {
 			_, matcherSourceCodes := mockgen.GenerateOutput(ast, "irrelevant", "MockDisplay", "test_package", "")
 
 			Expect(matcherSourceCodes).To(SatisfyAll(
-				HaveLen(10),
+				HaveLen(11),
 				HaveKeyWithValue("http_request", SatisfyAll(
 					ContainSubstring("http \"net/http\""),
 					ContainSubstring("func AnyHttpRequest() http.Request"),
@@ -50,6 +50,10 @@ var _ = Describe("Mockgen", func() {
 				)),
 				HaveKeyWithValue("map_of_int_to_int", SatisfyAll(
 					ContainSubstring("func AnyMapOfIntToInt() map[int]int"),
+				)),
+				HaveKeyWithValue("map_of_http_file_to_http_file", SatisfyAll(
+					ContainSubstring("http \"net/http\""),
+					Not(MatchRegexp("http \"net/http\"\\s+http \"net/http\"")),
 				)),
 			))
 		})

--- a/test_interface/display.go
+++ b/test_interface/display.go
@@ -45,4 +45,5 @@ type Display interface {
 	ChanParams(<-chan string, chan<- error)
 	ChanReturnValues() (<-chan string, chan<- error)
 	VariadicWithNonPrimitiveType(m ...map[int]int)
+	MapWithRedundantImports(m map[http.File]http.File)
 }


### PR DESCRIPTION
Fixes #105 