### PR TITLE
Fix empty unnamed struct matcher generation

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -490,12 +490,18 @@ func spaceSeparatedNameFor(t model.Type, packageMap map[string]string) string {
 	switch typedType := t.(type) {
 	case model.PredeclaredType:
 		tt := typedType.String(packageMap, "")
-		if tt == "interface{}" {
+		switch tt {
+		case "interface{}":
 			// if a predeclared type is interface
 			// return a string type without curly brackets
 			return "interface"
+		case "struct{}":
+			// if a predeclared type is an empty unnamed struct
+			// return a string type without curly brackets
+			return "empty unnamed struct"
+		default:
+			return tt
 		}
-		return tt
 	case *model.NamedType:
 		return strings.Replace((typedType.String(packageMap, "")), ".", " ", -1)
 	case *model.PointerType:

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Mockgen", func() {
 			_, matcherSourceCodes := mockgen.GenerateOutput(ast, "irrelevant", "MockDisplay", "test_package", "")
 
 			Expect(matcherSourceCodes).To(SatisfyAll(
-				HaveLen(11),
+				HaveLen(12),
 				HaveKeyWithValue("http_request", SatisfyAll(
 					ContainSubstring("http \"net/http\""),
 					ContainSubstring("func AnyHttpRequest() http.Request"),
@@ -54,6 +54,9 @@ var _ = Describe("Mockgen", func() {
 				HaveKeyWithValue("map_of_http_file_to_http_file", SatisfyAll(
 					ContainSubstring("http \"net/http\""),
 					Not(MatchRegexp("http \"net/http\"\\s+http \"net/http\"")),
+				)),
+				HaveKeyWithValue("map_of_string_to_empty_unnamed_struct", SatisfyAll(
+					ContainSubstring("func AnyMapOfStringToEmptyUnnamedStruct() map[string]struct{}"),
 				)),
 			))
 		})

--- a/modelgen/loader/loader.go
+++ b/modelgen/loader/loader.go
@@ -157,7 +157,7 @@ func (g *modelGenerator) modelTypeFrom(typesType types.Type) model.Type {
 			Package: typedTyp.Obj().Pkg().Path(),
 			Type:    typedTyp.Obj().Name(),
 		}
-	case *types.Interface:
+	case *types.Interface, *types.Struct:
 		return model.PredeclaredType(typedTyp.String())
 	case *types.Signature:
 		in, variadic := g.generateInParamsFrom(typedTyp.Params())

--- a/test_interface/display.go
+++ b/test_interface/display.go
@@ -46,4 +46,5 @@ type Display interface {
 	ChanReturnValues() (<-chan string, chan<- error)
 	VariadicWithNonPrimitiveType(m ...map[int]int)
 	MapWithRedundantImports(m map[http.File]http.File)
+	MapOfStringToEmptyUnnamedStruct(m map[string]struct{})
 }


### PR DESCRIPTION
Fixes https://github.com/petergtz/pegomock/issues/101
* by replacing the name of unnamed `struct{}` types
* restrictive naming because non-empty `struct{}` types cannot be handled (yet) and are excluded here https://github.com/petergtz/pegomock/blob/5482ace33e29c090cd941dd9063721c39a9f2a83/modelgen/gomock/parse.go#L358 