### PR TITLE
Extracting separate ArgumentMatcher ifc with no FailureMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ When(contactList.getContactByFullName(EqString("Dan"), AnyString())).thenReturn(
 
 **Important:** `Eq...`, `NotEq...`, `Any...` and `...That` matchers for types used in mock methods,
 can now be _auto-generated_ while generating the mock. The `...That` argument matcher accepts an
-argument implementing the `pegomock.Matcher` interface and allows you to write and use custom
+argument implementing the `pegomock.ArgumentMatcher` interface and allows you to write and use custom
 matcher logic without having to create a new argument matcher method for each type you want to match.
 
 So writing your own argument matchers is not necessary for most use cases. See section

--- a/dsl.go
+++ b/dsl.go
@@ -95,7 +95,7 @@ func (genericMock *GenericMock) reset(methodName string, paramMatchers []Argumen
 
 func (genericMock *GenericMock) Verify(
 	inOrderContext *InOrderContext,
-	invocationCountMatcher Matcher,
+	invocationCountMatcher InvocationCountMatcher,
 	methodName string,
 	params []Param,
 	options ...interface{},
@@ -528,17 +528,23 @@ type InOrderContext struct {
 	lastInvokedMethodParams []Param
 }
 
-// ArgumentMatcher can be used to match arguments but not invocation counts.
+// ArgumentMatcher can be used to match arguments.
 type ArgumentMatcher interface {
 	Matches(param Param) bool
 	fmt.Stringer
 }
 
-// Matcher can be used to match arguments as well as invocation counts. It is guaranteed that
+// InvocationCountMatcher can be used to match invocation counts. It is guaranteed that
 // FailureMessage will always be called after Matches so an implementation can save state.
+type InvocationCountMatcher interface {
+	Matches(param Param) bool
+	FailureMessage() string
+}
+
+// Matcher can be used to match arguments as well as invocation counts.
 type Matcher interface {
 	ArgumentMatcher
-	FailureMessage() string
+	InvocationCountMatcher
 }
 
 func DumpInvocationsFor(mock Mock) {

--- a/dsl.go
+++ b/dsl.go
@@ -43,7 +43,7 @@ var (
 
 var globalArgMatchers Matchers
 
-func RegisterMatcher(matcher Matcher) {
+func RegisterMatcher(matcher ArgumentMatcher) {
 	globalArgMatchers.append(matcher)
 }
 
@@ -72,11 +72,11 @@ func (genericMock *GenericMock) Invoke(methodName string, params []Param, return
 	return genericMock.getOrCreateMockedMethod(methodName).Invoke(params)
 }
 
-func (genericMock *GenericMock) stub(methodName string, paramMatchers []Matcher, returnValues ReturnValues) {
+func (genericMock *GenericMock) stub(methodName string, paramMatchers []ArgumentMatcher, returnValues ReturnValues) {
 	genericMock.stubWithCallback(methodName, paramMatchers, func([]Param) ReturnValues { return returnValues })
 }
 
-func (genericMock *GenericMock) stubWithCallback(methodName string, paramMatchers []Matcher, callback func([]Param) ReturnValues) {
+func (genericMock *GenericMock) stubWithCallback(methodName string, paramMatchers []ArgumentMatcher, callback func([]Param) ReturnValues) {
 	genericMock.getOrCreateMockedMethod(methodName).stub(paramMatchers, callback)
 }
 
@@ -89,7 +89,7 @@ func (genericMock *GenericMock) getOrCreateMockedMethod(methodName string) *mock
 	return genericMock.mockedMethods[methodName]
 }
 
-func (genericMock *GenericMock) reset(methodName string, paramMatchers []Matcher) {
+func (genericMock *GenericMock) reset(methodName string, paramMatchers []ArgumentMatcher) {
 	genericMock.getOrCreateMockedMethod(methodName).reset(paramMatchers)
 }
 
@@ -175,7 +175,7 @@ func (genericMock *GenericMock) GetInvocationParams(methodInvocations []MethodIn
 	return result
 }
 
-func (genericMock *GenericMock) methodInvocations(methodName string, params []Param, matchers []Matcher) []MethodInvocation {
+func (genericMock *GenericMock) methodInvocations(methodName string, params []Param, matchers []ArgumentMatcher) []MethodInvocation {
 	var invocations []MethodInvocation
 	if method, exists := genericMock.mockedMethods[methodName]; exists {
 		method.Lock()
@@ -224,7 +224,7 @@ func formatParams(params []Param) (result string) {
 	return
 }
 
-func formatMatchers(matchers []Matcher) (result string) {
+func formatMatchers(matchers []ArgumentMatcher) (result string) {
 	for i, matcher := range matchers {
 		if i > 0 {
 			result += ", "
@@ -366,7 +366,7 @@ func (stubbing *Stubbing) Invoke(params []Param) ReturnValues {
 	return stubbing.callbackSequence[stubbing.sequencePointer](params)
 }
 
-type Matchers []Matcher
+type Matchers []ArgumentMatcher
 
 func (matchers Matchers) Matches(params []Param) bool {
 	if len(matchers) != len(params) { // Technically, this is not an error. Variadic arguments can cause this
@@ -381,14 +381,14 @@ func (matchers Matchers) Matches(params []Param) bool {
 	return true
 }
 
-func (matchers *Matchers) append(matcher Matcher) {
+func (matchers *Matchers) append(matcher ArgumentMatcher) {
 	*matchers = append(*matchers, matcher)
 }
 
 type ongoingStubbing struct {
 	genericMock   *GenericMock
 	MethodName    string
-	ParamMatchers []Matcher
+	ParamMatchers []ArgumentMatcher
 	returnTypes   []reflect.Type
 }
 
@@ -434,7 +434,7 @@ func actualTypeOf(iface interface{}) reflect.Type {
 	return reflect.TypeOf(iface)
 }
 
-func paramMatchersFromArgMatchersOrParams(argMatchers []Matcher, params []Param) []Matcher {
+func paramMatchersFromArgMatchersOrParams(argMatchers []ArgumentMatcher, params []Param) []ArgumentMatcher {
 	if len(argMatchers) != 0 {
 		verifyArgMatcherUse(argMatchers, params)
 		return argMatchers
@@ -442,7 +442,7 @@ func paramMatchersFromArgMatchersOrParams(argMatchers []Matcher, params []Param)
 	return transformParamsIntoEqMatchers(params)
 }
 
-func verifyArgMatcherUse(argMatchers []Matcher, params []Param) {
+func verifyArgMatcherUse(argMatchers []ArgumentMatcher, params []Param) {
 	verify.Argument(len(argMatchers) == len(params),
 		"Invalid use of matchers!\n\n %v matchers expected, %v recorded.\n\n"+
 			"This error may occur if matchers are combined with raw values:\n"+
@@ -456,8 +456,8 @@ func verifyArgMatcherUse(argMatchers []Matcher, params []Param) {
 	)
 }
 
-func transformParamsIntoEqMatchers(params []Param) []Matcher {
-	paramMatchers := make([]Matcher, len(params))
+func transformParamsIntoEqMatchers(params []Param) []ArgumentMatcher {
+	paramMatchers := make([]ArgumentMatcher, len(params))
 	for i, param := range params {
 		paramMatchers[i] = &EqMatcher{Value: param}
 	}
@@ -528,12 +528,17 @@ type InOrderContext struct {
 	lastInvokedMethodParams []Param
 }
 
-// Matcher ... it is guaranteed that FailureMessage will always be called after Matches
-// so an implementation can save state
-type Matcher interface {
+// ArgumentMatcher can be used to match arguments but not invocation counts.
+type ArgumentMatcher interface {
 	Matches(param Param) bool
-	FailureMessage() string
 	fmt.Stringer
+}
+
+// Matcher can be used to match arguments as well as invocation counts. It is guaranteed that
+// FailureMessage will always be called after Matches so an implementation can save state.
+type Matcher interface {
+	ArgumentMatcher
+	FailureMessage() string
 }
 
 func DumpInvocationsFor(mock Mock) {

--- a/dsl.go
+++ b/dsl.go
@@ -542,9 +542,12 @@ type InvocationCountMatcher interface {
 }
 
 // Matcher can be used to match arguments as well as invocation counts.
+// Note that support for overlapping embedded interfaces was added in Go 1.14, which is why
+// ArgumentMatcher and InvocationCountMatcher are not embedded here.
 type Matcher interface {
-	ArgumentMatcher
-	InvocationCountMatcher
+	Matches(param Param) bool
+	FailureMessage() string
+	fmt.Stringer
 }
 
 func DumpInvocationsFor(mock Mock) {

--- a/internal/generate_matchers/matcher_generation.go
+++ b/internal/generate_matchers/matcher_generation.go
@@ -12,51 +12,148 @@ import (
 //     go generate github.com/petergtz/pegomock/internal/generate_matchers
 
 //go:generate go run matcher_generation.go
+//go:generate go fmt ../../matcher_factories.go
+//go:generate go fmt ../../ginkgo_compatible/matchers.go
 
 func main() {
-	err := ioutil.WriteFile(
-		"../../matcher_factories.go",
-		[]byte(GenerateDefaultMatchersFile()),
-		0644)
+	mustWriteFile("../../matcher_factories.go", GenerateDefaultMatchersFile())
+	mustWriteFile("../../ginkgo_compatible/matchers.go", GenerateGinkgoMatchersFile())
+}
+
+func mustWriteFile(path string, contents string) {
+	err := ioutil.WriteFile(path, []byte(contents), 0644)
 	if err != nil {
 		panic(err)
 	}
 }
 
 func GenerateDefaultMatchersFile() string {
-	return fmt.Sprintf(`package pegomock
+	contents := `package pegomock
 
 import (
 	"reflect"
 )
+`
 
-%s
-	`, GenerateDefaultMatchers())
+	for _, kind := range primitiveKinds {
+		contents += fmt.Sprintf(`
+func Eq%[1]s(value %[2]s) %[2]s {
+	RegisterMatcher(&EqMatcher{Value: value})
+	return %[4]s
 }
 
-func GenerateDefaultMatchers() string {
-	result := ""
-	for _, kind := range primitiveKinds {
-		result += GenerateEqMatcherFactory(kind) +
-			GenerateAnyMatcherFactory(kind) +
-			GenerateAnySliceMatcherFactory(kind)
-	}
-	// hard-coding this for now as interface{} overall works slighly different than other types.
-	result += `func EqInterface(value interface{}) interface{} {
+func NotEq%[1]s(value %[2]s) %[2]s {
+	RegisterMatcher(&NotEqMatcher{Value: value})
+	return %[4]s
+}
+
+func Any%[1]s() %[2]s {
+	RegisterMatcher(NewAnyMatcher(reflect.TypeOf(%[3]s)))
+	return %[4]s
+}
+
+func %[1]sThat(matcher ArgumentMatcher) %[2]s {
+	RegisterMatcher(matcher)
+	return %[4]s
+}
+
+func Eq%[1]sSlice(value []%[2]s) []%[2]s {
 	RegisterMatcher(&EqMatcher{Value: value})
 	return nil
 }
 
+func NotEq%[1]sSlice(value []%[2]s) []%[2]s {
+	RegisterMatcher(&NotEqMatcher{Value: value})
+	return nil
+}
+
+func Any%[1]sSlice() []%[2]s {
+	RegisterMatcher(NewAnyMatcher(reflect.SliceOf(reflect.TypeOf(%[3]s))))
+	return nil
+}
+
+func %[1]sSliceThat(matcher ArgumentMatcher) []%[2]s {
+	RegisterMatcher(matcher)
+	return nil
+}
+`, strings.Title(kind.String()), kind.String(), exampleValue(kind), zeroValue(kind))
+	}
+
+	// hard-coding this for now as interface{} overall works slightly different than other types.
+	return contents + `
+func EqInterface(value interface{}) interface{} {
+	RegisterMatcher(&EqMatcher{Value: value})
+	return nil
+}
+
+func NotEqInterface(value interface{}) interface{} {
+	RegisterMatcher(&NotEqMatcher{Value: value})
+	return nil
+}
+
 func AnyInterface() interface{} {
-	RegisterMatcher(NewAnyMatcher(reflect.TypeOf((*(interface{}))(nil)).Elem()))
+	RegisterMatcher(NewAnyMatcher(reflect.TypeOf((*interface{})(nil)).Elem()))
+	return nil
+}
+
+func InterfaceThat(matcher ArgumentMatcher) interface{} {
+	RegisterMatcher(matcher)
+	return nil
+}
+
+func EqInterfaceSlice(value []interface{}) []interface{} {
+	RegisterMatcher(&EqMatcher{Value: value})
+	return nil
+}
+
+func NotEqInterfaceSlice(value []interface{}) []interface{} {
+	RegisterMatcher(&NotEqMatcher{Value: value})
 	return nil
 }
 
 func AnyInterfaceSlice() []interface{} {
-	RegisterMatcher(NewAnyMatcher(reflect.SliceOf(reflect.TypeOf((*(interface{}))(nil)).Elem())))
+	RegisterMatcher(NewAnyMatcher(reflect.SliceOf(reflect.TypeOf((*interface{})(nil)).Elem())))
 	return nil
-}`
-	return result
+}
+
+func InterfaceSliceThat(matcher ArgumentMatcher) []interface{} {
+	RegisterMatcher(matcher)
+	return nil
+}
+`
+}
+
+func GenerateGinkgoMatchersFile() string {
+	contents := `package mock
+
+import (
+	"github.com/petergtz/pegomock"
+)
+
+var (`
+
+	for _, kind := range append(primitiveKinds, reflect.Interface) {
+		contents += fmt.Sprintf(`
+	Eq%[1]s = pegomock.Eq%[1]s
+	NotEq%[1]s = pegomock.NotEq%[1]s
+	Any%[1]s = pegomock.Any%[1]s
+	%[1]sThat = pegomock.%[1]sThat
+	Eq%[1]sSlice = pegomock.Eq%[1]sSlice
+	NotEq%[1]sSlice = pegomock.NotEq%[1]sSlice
+	Any%[1]sSlice = pegomock.Any%[1]sSlice
+	%[1]sSliceThat = pegomock.%[1]sSliceThat
+`, strings.Title(kind.String()))
+	}
+
+	return contents + `
+	Times   = pegomock.Times
+	AtLeast = pegomock.AtLeast
+	AtMost  = pegomock.AtMost
+	Never   = pegomock.Never
+	Once    = pegomock.Once
+	Twice   = pegomock.Twice
+)
+`
 }
 
 var primitiveKinds = []reflect.Kind{
@@ -79,38 +176,9 @@ var primitiveKinds = []reflect.Kind{
 	reflect.String,
 }
 
-func GenerateEqMatcherFactory(kind reflect.Kind) string {
-	return fmt.Sprintf(`func Eq%s(value %s) %s {
-	RegisterMatcher(&EqMatcher{Value: value})
-	return %s
-}
+// TODO generate: chan, func matchers
 
-`, strings.Title(kind.String()), kind, kind, nullOf(kind))
-}
-
-func GenerateAnyMatcherFactory(kind reflect.Kind) string {
-	return fmt.Sprintf(`func Any%s() %s {
-	RegisterMatcher(NewAnyMatcher(reflect.TypeOf((%s)(%s))))
-	return %s
-}
-
-`, strings.Title(kind.String()), kind, kind.String(), nullOf(kind), nullOf(kind))
-}
-
-func GenerateAnySliceMatcherFactory(kind reflect.Kind) string {
-	return fmt.Sprintf(`func Any%sSlice() []%s {
-	RegisterMatcher(NewAnyMatcher(reflect.SliceOf(reflect.TypeOf((%s)(%s)))))
-	return nil
-}
-
-`, strings.Title(kind.String()), kind.String(), kind.String(), nullOf(kind))
-}
-
-// TODO generate:
-// Eq Slice matchers
-// generate chan, func matchers
-
-func nullOf(kind reflect.Kind) string {
+func zeroValue(kind reflect.Kind) string {
 	switch {
 	case kind == reflect.Bool:
 		return `false`
@@ -119,6 +187,13 @@ func nullOf(kind reflect.Kind) string {
 	case kind == reflect.String:
 		return `""`
 	default:
-		return "nil"
+		return `nil`
 	}
+}
+
+func exampleValue(kind reflect.Kind) string {
+	if kind == reflect.Bool || kind == reflect.Int || kind == reflect.String {
+		return zeroValue(kind)
+	}
+	return fmt.Sprintf("(%s)(%s)", kind.String(), zeroValue(kind))
 }

--- a/matcher_factories.go
+++ b/matcher_factories.go
@@ -19,7 +19,7 @@ func AnyBool() bool {
 	return false
 }
 
-func BoolThat(matcher Matcher) bool {
+func BoolThat(matcher ArgumentMatcher) bool {
 	RegisterMatcher(matcher)
 	return false
 }
@@ -39,7 +39,7 @@ func AnyBoolSlice() []bool {
 	return nil
 }
 
-func BoolSliceThat(matcher Matcher) []bool {
+func BoolSliceThat(matcher ArgumentMatcher) []bool {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -59,7 +59,7 @@ func AnyInt() int {
 	return 0
 }
 
-func IntThat(matcher Matcher) int {
+func IntThat(matcher ArgumentMatcher) int {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -79,7 +79,7 @@ func AnyIntSlice() []int {
 	return nil
 }
 
-func IntSliceThat(matcher Matcher) []int {
+func IntSliceThat(matcher ArgumentMatcher) []int {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -99,7 +99,7 @@ func AnyInt8() int8 {
 	return 0
 }
 
-func Int8That(matcher Matcher) int8 {
+func Int8That(matcher ArgumentMatcher) int8 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -119,7 +119,7 @@ func AnyInt8Slice() []int8 {
 	return nil
 }
 
-func Int8SliceThat(matcher Matcher) []int8 {
+func Int8SliceThat(matcher ArgumentMatcher) []int8 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -139,7 +139,7 @@ func AnyInt16() int16 {
 	return 0
 }
 
-func Int16That(matcher Matcher) int16 {
+func Int16That(matcher ArgumentMatcher) int16 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -159,7 +159,7 @@ func AnyInt16Slice() []int16 {
 	return nil
 }
 
-func Int16SliceThat(matcher Matcher) []int16 {
+func Int16SliceThat(matcher ArgumentMatcher) []int16 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -179,7 +179,7 @@ func AnyInt32() int32 {
 	return 0
 }
 
-func Int32That(matcher Matcher) int32 {
+func Int32That(matcher ArgumentMatcher) int32 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -199,7 +199,7 @@ func AnyInt32Slice() []int32 {
 	return nil
 }
 
-func Int32SliceThat(matcher Matcher) []int32 {
+func Int32SliceThat(matcher ArgumentMatcher) []int32 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -219,7 +219,7 @@ func AnyInt64() int64 {
 	return 0
 }
 
-func Int64That(matcher Matcher) int64 {
+func Int64That(matcher ArgumentMatcher) int64 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -239,7 +239,7 @@ func AnyInt64Slice() []int64 {
 	return nil
 }
 
-func Int64SliceThat(matcher Matcher) []int64 {
+func Int64SliceThat(matcher ArgumentMatcher) []int64 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -259,7 +259,7 @@ func AnyUint() uint {
 	return 0
 }
 
-func UintThat(matcher Matcher) uint {
+func UintThat(matcher ArgumentMatcher) uint {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -279,7 +279,7 @@ func AnyUintSlice() []uint {
 	return nil
 }
 
-func UintSliceThat(matcher Matcher) []uint {
+func UintSliceThat(matcher ArgumentMatcher) []uint {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -299,7 +299,7 @@ func AnyUint8() uint8 {
 	return 0
 }
 
-func Uint8That(matcher Matcher) uint8 {
+func Uint8That(matcher ArgumentMatcher) uint8 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -319,7 +319,7 @@ func AnyUint8Slice() []uint8 {
 	return nil
 }
 
-func Uint8SliceThat(matcher Matcher) []uint8 {
+func Uint8SliceThat(matcher ArgumentMatcher) []uint8 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -339,7 +339,7 @@ func AnyUint16() uint16 {
 	return 0
 }
 
-func Uint16That(matcher Matcher) uint16 {
+func Uint16That(matcher ArgumentMatcher) uint16 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -359,7 +359,7 @@ func AnyUint16Slice() []uint16 {
 	return nil
 }
 
-func Uint16SliceThat(matcher Matcher) []uint16 {
+func Uint16SliceThat(matcher ArgumentMatcher) []uint16 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -379,7 +379,7 @@ func AnyUint32() uint32 {
 	return 0
 }
 
-func Uint32That(matcher Matcher) uint32 {
+func Uint32That(matcher ArgumentMatcher) uint32 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -399,7 +399,7 @@ func AnyUint32Slice() []uint32 {
 	return nil
 }
 
-func Uint32SliceThat(matcher Matcher) []uint32 {
+func Uint32SliceThat(matcher ArgumentMatcher) []uint32 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -419,7 +419,7 @@ func AnyUint64() uint64 {
 	return 0
 }
 
-func Uint64That(matcher Matcher) uint64 {
+func Uint64That(matcher ArgumentMatcher) uint64 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -439,7 +439,7 @@ func AnyUint64Slice() []uint64 {
 	return nil
 }
 
-func Uint64SliceThat(matcher Matcher) []uint64 {
+func Uint64SliceThat(matcher ArgumentMatcher) []uint64 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -459,7 +459,7 @@ func AnyUintptr() uintptr {
 	return 0
 }
 
-func UintptrThat(matcher Matcher) uintptr {
+func UintptrThat(matcher ArgumentMatcher) uintptr {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -479,7 +479,7 @@ func AnyUintptrSlice() []uintptr {
 	return nil
 }
 
-func UintptrSliceThat(matcher Matcher) []uintptr {
+func UintptrSliceThat(matcher ArgumentMatcher) []uintptr {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -499,7 +499,7 @@ func AnyFloat32() float32 {
 	return 0
 }
 
-func Float32That(matcher Matcher) float32 {
+func Float32That(matcher ArgumentMatcher) float32 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -519,7 +519,7 @@ func AnyFloat32Slice() []float32 {
 	return nil
 }
 
-func Float32SliceThat(matcher Matcher) []float32 {
+func Float32SliceThat(matcher ArgumentMatcher) []float32 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -539,7 +539,7 @@ func AnyFloat64() float64 {
 	return 0
 }
 
-func Float64That(matcher Matcher) float64 {
+func Float64That(matcher ArgumentMatcher) float64 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -559,7 +559,7 @@ func AnyFloat64Slice() []float64 {
 	return nil
 }
 
-func Float64SliceThat(matcher Matcher) []float64 {
+func Float64SliceThat(matcher ArgumentMatcher) []float64 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -579,7 +579,7 @@ func AnyComplex64() complex64 {
 	return 0
 }
 
-func Complex64That(matcher Matcher) complex64 {
+func Complex64That(matcher ArgumentMatcher) complex64 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -599,7 +599,7 @@ func AnyComplex64Slice() []complex64 {
 	return nil
 }
 
-func Complex64SliceThat(matcher Matcher) []complex64 {
+func Complex64SliceThat(matcher ArgumentMatcher) []complex64 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -619,7 +619,7 @@ func AnyComplex128() complex128 {
 	return 0
 }
 
-func Complex128That(matcher Matcher) complex128 {
+func Complex128That(matcher ArgumentMatcher) complex128 {
 	RegisterMatcher(matcher)
 	return 0
 }
@@ -639,7 +639,7 @@ func AnyComplex128Slice() []complex128 {
 	return nil
 }
 
-func Complex128SliceThat(matcher Matcher) []complex128 {
+func Complex128SliceThat(matcher ArgumentMatcher) []complex128 {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -659,7 +659,7 @@ func AnyString() string {
 	return ""
 }
 
-func StringThat(matcher Matcher) string {
+func StringThat(matcher ArgumentMatcher) string {
 	RegisterMatcher(matcher)
 	return ""
 }
@@ -679,7 +679,7 @@ func AnyStringSlice() []string {
 	return nil
 }
 
-func StringSliceThat(matcher Matcher) []string {
+func StringSliceThat(matcher ArgumentMatcher) []string {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -699,7 +699,7 @@ func AnyInterface() interface{} {
 	return nil
 }
 
-func InterfaceThat(matcher Matcher) interface{} {
+func InterfaceThat(matcher ArgumentMatcher) interface{} {
 	RegisterMatcher(matcher)
 	return nil
 }
@@ -719,7 +719,7 @@ func AnyInterfaceSlice() []interface{} {
 	return nil
 }
 
-func InterfaceSliceThat(matcher Matcher) []interface{} {
+func InterfaceSliceThat(matcher ArgumentMatcher) []interface{} {
 	RegisterMatcher(matcher)
 	return nil
 }

--- a/matchers/http_request.go
+++ b/matchers/http_request.go
@@ -26,7 +26,7 @@ func NotEqHttpRequest(value http.Request) http.Request {
 	return nullValue
 }
 
-func HttpRequestThat(matcher pegomock.Matcher) http.Request {
+func HttpRequestThat(matcher pegomock.ArgumentMatcher) http.Request {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue http.Request
 	return nullValue

--- a/matchers/io_readcloser.go
+++ b/matchers/io_readcloser.go
@@ -26,7 +26,7 @@ func NotEqIoReadCloser(value io.ReadCloser) io.ReadCloser {
 	return nullValue
 }
 
-func IoReadCloserThat(matcher pegomock.Matcher) io.ReadCloser {
+func IoReadCloserThat(matcher pegomock.ArgumentMatcher) io.ReadCloser {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue io.ReadCloser
 	return nullValue

--- a/matchers/map_of_http_file_to_http_file.go
+++ b/matchers/map_of_http_file_to_http_file.go
@@ -26,7 +26,7 @@ func NotEqMapOfHttpFileToHttpFile(value map[http.File]http.File) map[http.File]h
 	return nullValue
 }
 
-func MapOfHttpFileToHttpFileThat(matcher pegomock.Matcher) map[http.File]http.File {
+func MapOfHttpFileToHttpFileThat(matcher pegomock.ArgumentMatcher) map[http.File]http.File {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue map[http.File]http.File
 	return nullValue

--- a/matchers/map_of_int_to_int.go
+++ b/matchers/map_of_int_to_int.go
@@ -24,7 +24,7 @@ func NotEqMapOfIntToInt(value map[int]int) map[int]int {
 	return nullValue
 }
 
-func MapOfIntToIntThat(matcher pegomock.Matcher) map[int]int {
+func MapOfIntToIntThat(matcher pegomock.ArgumentMatcher) map[int]int {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue map[int]int
 	return nullValue

--- a/matchers/map_of_string_to_empty_unnamed_struct.go
+++ b/matchers/map_of_string_to_empty_unnamed_struct.go
@@ -24,7 +24,7 @@ func NotEqMapOfStringToEmptyUnnamedStruct(value map[string]struct{}) map[string]
 	return nullValue
 }
 
-func MapOfStringToEmptyUnnamedStructThat(matcher pegomock.Matcher) map[string]struct{} {
+func MapOfStringToEmptyUnnamedStructThat(matcher pegomock.ArgumentMatcher) map[string]struct{} {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue map[string]struct{}
 	return nullValue

--- a/matchers/map_of_string_to_http_request.go
+++ b/matchers/map_of_string_to_http_request.go
@@ -26,7 +26,7 @@ func NotEqMapOfStringToHttpRequest(value map[string]http.Request) map[string]htt
 	return nullValue
 }
 
-func MapOfStringToHttpRequestThat(matcher pegomock.Matcher) map[string]http.Request {
+func MapOfStringToHttpRequestThat(matcher pegomock.ArgumentMatcher) map[string]http.Request {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue map[string]http.Request
 	return nullValue

--- a/matchers/map_of_string_to_interface.go
+++ b/matchers/map_of_string_to_interface.go
@@ -24,7 +24,7 @@ func NotEqMapOfStringToInterface(value map[string]interface{}) map[string]interf
 	return nullValue
 }
 
-func MapOfStringToInterfaceThat(matcher pegomock.Matcher) map[string]interface{} {
+func MapOfStringToInterfaceThat(matcher pegomock.ArgumentMatcher) map[string]interface{} {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue map[string]interface{}
 	return nullValue

--- a/matchers/ptr_to_http_request.go
+++ b/matchers/ptr_to_http_request.go
@@ -26,7 +26,7 @@ func NotEqPtrToHttpRequest(value *http.Request) *http.Request {
 	return nullValue
 }
 
-func PtrToHttpRequestThat(matcher pegomock.Matcher) *http.Request {
+func PtrToHttpRequestThat(matcher pegomock.ArgumentMatcher) *http.Request {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue *http.Request
 	return nullValue

--- a/matchers/recv_chan_of_string.go
+++ b/matchers/recv_chan_of_string.go
@@ -24,7 +24,7 @@ func NotEqRecvChanOfString(value <-chan string) <-chan string {
 	return nullValue
 }
 
-func RecvChanOfStringThat(matcher pegomock.Matcher) <-chan string {
+func RecvChanOfStringThat(matcher pegomock.ArgumentMatcher) <-chan string {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue <-chan string
 	return nullValue

--- a/matchers/send_chan_of_error.go
+++ b/matchers/send_chan_of_error.go
@@ -24,7 +24,7 @@ func NotEqSendChanOfError(value chan<- error) chan<- error {
 	return nullValue
 }
 
-func SendChanOfErrorThat(matcher pegomock.Matcher) chan<- error {
+func SendChanOfErrorThat(matcher pegomock.ArgumentMatcher) chan<- error {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue chan<- error
 	return nullValue

--- a/matchers/slice_of_string.go
+++ b/matchers/slice_of_string.go
@@ -24,7 +24,7 @@ func NotEqSliceOfString(value []string) []string {
 	return nullValue
 }
 
-func SliceOfStringThat(matcher pegomock.Matcher) []string {
+func SliceOfStringThat(matcher pegomock.ArgumentMatcher) []string {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue []string
 	return nullValue

--- a/matchers/time_time.go
+++ b/matchers/time_time.go
@@ -26,7 +26,7 @@ func NotEqTimeTime(value time.Time) time.Time {
 	return nullValue
 }
 
-func TimeTimeThat(matcher pegomock.Matcher) time.Time {
+func TimeTimeThat(matcher pegomock.ArgumentMatcher) time.Time {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue time.Time
 	return nullValue

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -458,7 +458,7 @@ func NotEq%v(value %v) %v {
 	return nullValue
 }
 
-func %vThat(matcher pegomock.Matcher) %v {
+func %vThat(matcher pegomock.ArgumentMatcher) %v {
 	pegomock.RegisterMatcher(matcher)
 	var nullValue %v
 	return nullValue

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -239,7 +239,7 @@ func (g *generator) generateVerifierType(interfaceName string) *generator {
 	return g.
 		p("type Verifier%v struct {", interfaceName).
 		p("	mock *%v", interfaceName).
-		p("	invocationCountMatcher pegomock.Matcher").
+		p("	invocationCountMatcher pegomock.InvocationCountMatcher").
 		p("	inOrderContext *pegomock.InOrderContext").
 		p("	timeout time.Duration").
 		p("}").
@@ -255,14 +255,14 @@ func (g *generator) generateMockVerifyMethods(interfaceName string) {
 		p("	}").
 		p("}").
 		emptyLine().
-		p("func (mock *%v) VerifyWasCalled(invocationCountMatcher pegomock.Matcher) *Verifier%v {", interfaceName, interfaceName).
+		p("func (mock *%v) VerifyWasCalled(invocationCountMatcher pegomock.InvocationCountMatcher) *Verifier%v {", interfaceName, interfaceName).
 		p("	return &Verifier%v{", interfaceName).
 		p("		mock: mock,").
 		p("		invocationCountMatcher: invocationCountMatcher,").
 		p("	}").
 		p("}").
 		emptyLine().
-		p("func (mock *%v) VerifyWasCalledInOrder(invocationCountMatcher pegomock.Matcher, inOrderContext *pegomock.InOrderContext) *Verifier%v {", interfaceName, interfaceName).
+		p("func (mock *%v) VerifyWasCalledInOrder(invocationCountMatcher pegomock.InvocationCountMatcher, inOrderContext *pegomock.InOrderContext) *Verifier%v {", interfaceName, interfaceName).
 		p("	return &Verifier%v{", interfaceName).
 		p("		mock: mock,").
 		p("		invocationCountMatcher: invocationCountMatcher,").
@@ -270,7 +270,7 @@ func (g *generator) generateMockVerifyMethods(interfaceName string) {
 		p("	}").
 		p("}").
 		emptyLine().
-		p("func (mock *%v) VerifyWasCalledEventually(invocationCountMatcher pegomock.Matcher, timeout time.Duration) *Verifier%v {", interfaceName, interfaceName).
+		p("func (mock *%v) VerifyWasCalledEventually(invocationCountMatcher pegomock.InvocationCountMatcher, timeout time.Duration) *Verifier%v {", interfaceName, interfaceName).
 		p("	return &Verifier%v{", interfaceName).
 		p("		mock: mock,").
 		p("		invocationCountMatcher: invocationCountMatcher,").


### PR DESCRIPTION
Since `FailureMessage()` is only used for invocation count matching this will significantly simplify writing custom argument matchers - one less method to implement, no need for mutable state and synchronization.