### PR TITLE
rename mockgen variables like  `_ret1`, `_result` and `_params` not to conflict with method args

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -217,7 +217,7 @@ func (g *generator) generateMockMethod(mockType string, typeParamNames string, m
 	}
 	resultAssignment := ""
 	if len(method.Out) > 0 {
-		resultAssignment = "result :="
+		resultAssignment = "_result :="
 	}
 	g.p("%v pegomock.GetGenericMockFrom(mock).Invoke(\"%v\", _params, []reflect.Type{%v})",
 		resultAssignment, method.Name, strings.Join(reflectReturnTypes, ", "))
@@ -226,20 +226,20 @@ func (g *generator) generateMockMethod(mockType string, typeParamNames string, m
 		for i, returnType := range returnTypes {
 			g.p("var ret%v %v", i, returnType.String(g.packageMap, pkgOverride))
 		}
-		g.p("if len(result) != 0 {")
+		g.p("if len(_result) != 0 {")
 		returnValues := make([]string, len(returnTypes))
 		for i, returnType := range returnTypes {
-			g.p("if result[%v] != nil {", i)
+			g.p("if _result[%v] != nil {", i)
 			if chanType, isChanType := returnType.(*model.ChanType); isChanType && chanType.Dir != 0 {
 				undirectedChanType := *chanType
 				undirectedChanType.Dir = 0
 				g.p("var ok bool").
-					p("  ret%v, ok = result[%v].(%v)", i, i, undirectedChanType.String(g.packageMap, pkgOverride))
+					p("  ret%v, ok = _result[%v].(%v)", i, i, undirectedChanType.String(g.packageMap, pkgOverride))
 				g.p("if !ok{").
-					p("ret%v = result[%v].(%v)", i, i, chanType.String(g.packageMap, pkgOverride)).
+					p("ret%v = _result[%v].(%v)", i, i, chanType.String(g.packageMap, pkgOverride)).
 					p("}")
 			} else {
-				g.p("ret%v  = result[%v].(%v)", i, i, returnType.String(g.packageMap, pkgOverride))
+				g.p("ret%v  = _result[%v].(%v)", i, i, returnType.String(g.packageMap, pkgOverride))
 			}
 			g.p("}")
 			returnValues[i] = fmt.Sprintf("ret%v", i)

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -224,7 +224,7 @@ func (g *generator) generateMockMethod(mockType string, typeParamNames string, m
 	if len(method.Out) > 0 {
 		// TODO: translate LastInvocation into a Matcher so it can be used as key for Stubbings
 		for i, returnType := range returnTypes {
-			g.p("var ret%v %v", i, returnType.String(g.packageMap, pkgOverride))
+			g.p("var _ret%v %v", i, returnType.String(g.packageMap, pkgOverride))
 		}
 		g.p("if len(_result) != 0 {")
 		returnValues := make([]string, len(returnTypes))
@@ -234,15 +234,15 @@ func (g *generator) generateMockMethod(mockType string, typeParamNames string, m
 				undirectedChanType := *chanType
 				undirectedChanType.Dir = 0
 				g.p("var ok bool").
-					p("  ret%v, ok = _result[%v].(%v)", i, i, undirectedChanType.String(g.packageMap, pkgOverride))
+					p("  _ret%v, ok = _result[%v].(%v)", i, i, undirectedChanType.String(g.packageMap, pkgOverride))
 				g.p("if !ok{").
-					p("ret%v = _result[%v].(%v)", i, i, chanType.String(g.packageMap, pkgOverride)).
+					p("_ret%v = _result[%v].(%v)", i, i, chanType.String(g.packageMap, pkgOverride)).
 					p("}")
 			} else {
-				g.p("ret%v  = _result[%v].(%v)", i, i, returnType.String(g.packageMap, pkgOverride))
+				g.p("_ret%v  = _result[%v].(%v)", i, i, returnType.String(g.packageMap, pkgOverride))
 			}
 			g.p("}")
-			returnValues[i] = fmt.Sprintf("ret%v", i)
+			returnValues[i] = fmt.Sprintf("_ret%v", i)
 		}
 		g.p("}")
 		g.p("return %v", strings.Join(returnValues, ", "))


### PR DESCRIPTION
~~Please make sure to open your PR against the `develop` branch.~~

v4 commits doesn't exists in `develop` branch, so PR is created into `main`.

## Issue

closes https://github.com/petergtz/pegomock/issues/123

## Generated code

<details>
<summary>diff</summary>

```diff
diff --git a/server/core/runtime/mocks/mock_status_updater.go b/server/core/runtime/mocks/mock_status_updater.go
index 63da713a..a8584dfb 100644
--- a/server/core/runtime/mocks/mock_status_updater.go
+++ b/server/core/runtime/mocks/mock_status_updater.go
@@ -30,15 +30,15 @@ func (mock *MockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName
        if mock == nil {
                panic("mock must not be nil. Use myMock := NewMockStatusUpdater().")
        }
-       params := []pegomock.Param{ctx, cmdName, status, url, result}
-       pegomockResult := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
-       var ret0 error
-       if len(pegomockResult) != 0 {
-               if pegomockResult[0] != nil {
-                       ret0 = pegomockResult[0].(error)
+       _params := []pegomock.Param{ctx, cmdName, status, url, result}
+       _result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", _params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+       var _ret0 error
+       if len(_result) != 0 {
+               if _result[0] != nil {
+                       _ret0 = _result[0].(error)
                }
        }
-       return ret0
+       return _ret0
 }

 func (mock *MockStatusUpdater) VerifyWasCalledOnce() *VerifierMockStatusUpdater {
@@ -79,8 +79,8 @@ type VerifierMockStatusUpdater struct {
 }

 func (verifier *VerifierMockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) *MockStatusUpdater_UpdateProject_OngoingVerification {
-       params := []pegomock.Param{ctx, cmdName, status, url, result}
-       methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", params, verifier.timeout)
+       _params := []pegomock.Param{ctx, cmdName, status, url, result}
+       methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", _params, verifier.timeout)
        return &MockStatusUpdater_UpdateProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }

@@ -95,26 +95,26 @@ func (c *MockStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArgumen
 }
 }

 func (c *MockStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []command.Name, _param2 []models.CommitStatus, _param3 []string, _param4 []*command.ProjectResult) {
-       params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-       if len(params) > 0 {
+       _params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+       if len(_params) > 0 {
                _param0 = make([]command.ProjectContext, len(c.methodInvocations))
-               for u, param := range params[0] {
+               for u, param := range _params[0] {
                        _param0[u] = param.(command.ProjectContext)
                }
                _param1 = make([]command.Name, len(c.methodInvocations))
-               for u, param := range params[1] {
+               for u, param := range _params[1] {
                        _param1[u] = param.(command.Name)
                }
                _param2 = make([]models.CommitStatus, len(c.methodInvocations))
-               for u, param := range params[2] {
+               for u, param := range _params[2] {
                        _param2[u] = param.(models.CommitStatus)
                }
                _param3 = make([]string, len(c.methodInvocations))
-               for u, param := range params[3] {
+               for u, param := range _params[3] {
                        _param3[u] = param.(string)
                }
                _param4 = make([]*command.ProjectResult, len(c.methodInvocations))
-               for u, param := range params[4] {
+               for u, param := range _params[4] {
                        _param4[u] = param.(*command.ProjectResult)
                }
        }
```
</details>

<details>
<summary>generated code</summary>

```go
func (mock *MockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) error {
	if mock == nil {
		panic("mock must not be nil. Use myMock := NewMockStatusUpdater().")
	}
	_params := []pegomock.Param{ctx, cmdName, status, url, result}
	_result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", _params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
	var _ret0 error
	if len(_result) != 0 {
		if _result[0] != nil {
			_ret0 = _result[0].(error)
		}
	}
	return _ret0
}

func (c *MockStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []command.Name, _param2 []models.CommitStatus, _param3 []string, _param4 []*command.ProjectResult) {
	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
	if len(_params) > 0 {
		_param0 = make([]command.ProjectContext, len(c.methodInvocations))
		for u, param := range _params[0] {
			_param0[u] = param.(command.ProjectContext)
		}
		_param1 = make([]command.Name, len(c.methodInvocations))
		for u, param := range _params[1] {
			_param1[u] = param.(command.Name)
		}
		_param2 = make([]models.CommitStatus, len(c.methodInvocations))
		for u, param := range _params[2] {
			_param2[u] = param.(models.CommitStatus)
		}
		_param3 = make([]string, len(c.methodInvocations))
		for u, param := range _params[3] {
			_param3[u] = param.(string)
		}
		_param4 = make([]*command.ProjectResult, len(c.methodInvocations))
		for u, param := range _params[4] {
			_param4[u] = param.(*command.ProjectResult)
		}
	}
	return
}
```

</details>