### PR TITLE
support Alias type

### DIFF
--- a/modelgen/xtools_packages/packages.go
+++ b/modelgen/xtools_packages/packages.go
@@ -149,6 +149,14 @@ func modelTypeFrom(typesType types.Type) model.Type {
 			Dir:  dir,
 			Type: modelTypeFrom(typedTyp.Elem()),
 		}
+	case *types.Alias:
+		if typedTyp.Obj().Pkg() == nil {
+			return model.PredeclaredType(typedTyp.Obj().Name())
+		}
+		return &model.NamedType{
+			Package: typedTyp.Obj().Pkg().Path(),
+			Type:    typedTyp.Obj().Name(),
+		}
 	case *types.Named:
 		if typedTyp.Obj().Pkg() == nil {
 			return model.PredeclaredType(typedTyp.Obj().Name())


### PR DESCRIPTION
Updated a project to go-1.24, and pegomock started to fail when handling alias types.

Handling Alias type the same as Named types fixed it for me.

![5038580e3fa88c877e90c7210e2d3d7e](https://github.com/user-attachments/assets/022640dd-1c0b-46be-af91-a469e74e79df)

